### PR TITLE
fix(ci): build the CLI before publishing it

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,11 +86,16 @@ jobs:
           node -e "const f='apps/cli/package.json';const p=require('./'+f);p.version='${{ steps.ver.outputs.next }}';require('fs').writeFileSync(f, JSON.stringify(p,null,2)+'\n');"
           pnpm install --lockfile-only
 
-      # Builds the CLI (tsup + the vendor step) and validates the tarball
-      # without publishing it. Catches a missing vendored asset here rather
-      # than in someone's npx.
-      - name: Validate packaging (build + pack dry-run)
-        run: pnpm --filter @airshiplabs/cli publish --dry-run --no-git-checks --access public
+      # This step used to be `publish --dry-run`, which validated nothing:
+      # `pnpm publish` does not build the package (apps/cli has no prepack or
+      # prepare hook), so the dry run packed an empty tarball and exited 0.
+      # That is how v0.2.0 shipped with no dist/. Build explicitly, then pack
+      # for real and look inside.
+      - name: Build the CLI
+        run: pnpm turbo run build --filter=@airshiplabs/cli
+
+      - name: Validate packaging
+        run: bash scripts/verify-tarball.sh
 
       - name: Commit, tag and push
         if: ${{ inputs.dry_run == false }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,10 +42,20 @@ jobs:
             exit 1
           fi
 
-      # `pnpm publish` runs the package's build first, which is tsup plus
-      # scripts/vendor-assets.mjs — the step that puts the overlay bundles and
-      # the editor fonts inside the tarball. Without it the published CLI 404s
-      # on its own overlay.
+      # `pnpm publish` does NOT build the package. apps/cli has no prepack,
+      # prepare or prepublishOnly hook, and the npm lifecycle never invokes a
+      # plain `build` script — so nothing here builds unless this step does.
+      # Skip it and `files: ["dist"]` matches an empty directory, npm reports a
+      # clean publish, and the tarball ships a package.json and a LICENSE.
+      # v0.2.0 went out exactly that way.
+      - name: Build the CLI
+        run: pnpm turbo run build --filter=@airshiplabs/cli
+
+      # Packs for real and looks inside. `publish --dry-run` cannot stand in
+      # here — it packs the same empty tarball and exits 0.
+      - name: Verify the tarball is complete
+        run: bash scripts/verify-tarball.sh
+
       - name: Publish to npm
         run: pnpm --filter @airshiplabs/cli publish --access public --no-git-checks --provenance
         env:

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airshiplabs/cli",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Airship — a visual editor for your running web app, driven by Claude Code, Codex or OpenCode",
   "keywords": [
     "ai",

--- a/scripts/verify-tarball.sh
+++ b/scripts/verify-tarball.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Asserts the @airshiplabs/cli tarball is actually shippable before it goes out.
+#
+# Why this exists: `files: ["dist"]` silently matches nothing when dist/ has not
+# been built, so `pnpm publish` succeeds and ships a package.json and a LICENSE.
+# npm reports that as a clean publish, the version number is burned forever, and
+# the breakage only surfaces when a user runs `npx airship`. A --dry-run does not
+# catch it — it packs the same empty tarball and exits 0.
+#
+# So: pack for real, look inside, and fail loudly on anything missing.
+#
+#   bash scripts/verify-tarball.sh
+#
+# Assumes the CLI is already built (`pnpm turbo run build --filter=@airshiplabs/cli`).
+set -euo pipefail
+
+PKG_DIR="apps/cli"
+PKG_NAME="@airshiplabs/cli"
+
+# Every path the published CLI resolves at runtime but no bundler can inline.
+# dist/vendor/ is written by apps/cli/scripts/vendor-assets.mjs; without it the
+# installed CLI 404s on its own overlay and renders unstyled.
+REQUIRED=(
+  "package/package.json"
+  "package/dist/index.js"
+  "package/dist/vendor/overlay.global.js"
+  "package/dist/vendor/hook.global.js"
+  "package/dist/vendor/fonts/inter-variable.woff2"
+  "package/dist/vendor/fonts/jetbrains-mono-400.woff2"
+  "package/dist/vendor/fonts/jetbrains-mono-700.woff2"
+)
+
+# A correctly built tarball is ~1MB. An empty one is ~1.5KB. This catches the
+# shape of failure the per-file checks might miss if the layout ever changes.
+MIN_BYTES=200000
+
+cd "$(git rev-parse --show-toplevel)"
+[ -d "$PKG_DIR" ] || { echo "verify-tarball: $PKG_DIR not found" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+echo "» packing $PKG_NAME"
+( cd "$PKG_DIR" && npm pack --pack-destination "$WORK" >/dev/null )
+
+TARBALL="$(find "$WORK" -name '*.tgz' -maxdepth 1 | head -1)"
+[ -n "$TARBALL" ] || { echo "verify-tarball: npm pack produced no tarball" >&2; exit 1; }
+
+SIZE="$(wc -c < "$TARBALL" | tr -d ' ')"
+LISTING="$WORK/listing.txt"
+tar tzf "$TARBALL" > "$LISTING"
+
+MISSING=0
+for entry in "${REQUIRED[@]}"; do
+  if grep -qxF "$entry" "$LISTING"; then
+    echo "  ✓ ${entry#package/}"
+  else
+    echo "  ✖ ${entry#package/} — MISSING"
+    MISSING=1
+  fi
+done
+
+echo
+echo "  $(wc -l < "$LISTING" | tr -d ' ') files, $SIZE bytes"
+
+if [ "$MISSING" -ne 0 ]; then
+  echo >&2
+  echo "verify-tarball: the tarball is incomplete — refusing to publish." >&2
+  echo "  Build it first: pnpm turbo run build --filter=$PKG_NAME" >&2
+  exit 1
+fi
+
+if [ "$SIZE" -lt "$MIN_BYTES" ]; then
+  echo >&2
+  echo "verify-tarball: tarball is $SIZE bytes, expected at least $MIN_BYTES." >&2
+  echo "  Something is missing even though the required paths are present." >&2
+  exit 1
+fi
+
+echo "✓ tarball is complete"


### PR DESCRIPTION
## What broke

`@airshiplabs/cli@0.2.0` published green and is **broken on npm** — the tarball is 1,507 bytes containing `package.json` and `LICENSE`, no `dist/`. `bin` points at `./dist/index.js`, so `npx airship` fails with `could not determine executable to run`.

## Why

`pnpm publish` does not build the package. `apps/cli` has no `prepack`, `prepare` or `prepublishOnly` hook, and the npm lifecycle never invokes a plain `build` script. Locally `apps/cli/dist/` already exists from `make build`, so packing always looked correct; in a clean CI checkout `files: ["dist"]` matched an empty directory.

`publish.yml`'s "Validate packaging" step could not catch it — `publish --dry-run` packs the same empty tarball and exits 0. The comment in `release.yml` claiming publish builds first was incorrect.

## Fix

- `scripts/verify-tarball.sh` — packs for real and asserts `dist/index.js`, both vendored IIFEs and all three woff2 fonts, plus a 200KB size floor.
- Both lanes now run `pnpm turbo run build --filter=@airshiplabs/cli` and then the assertion before publishing.

## Verification

- Cold path: `rm -rf apps/cli/dist` → turbo build → verify → 26 files, 1.7MB, all assertions pass.
- Negative: with `dist/` absent the script exits 1 listing every missing path.
- `shellcheck` clean; both workflows parse with steps in the intended order.
- `dist/` is gitignored, so `git add -A` in *Commit, tag and push* stays clean.

0.2.0's version number is spent — npm never allows republishing one. This branch releases **0.2.1**, and 0.2.0 gets deprecated after.