### PR TITLE
fix: make the build work on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Check out everything with LF, even on Windows (core.autocrlf=true would
+# otherwise write CRLF, which breaks the front-matter regexes in the
+# editor-tokens/editor-icons/site-tokens gen scripts).
+* text=auto eol=lf

--- a/apps/cli/scripts/vendor-assets.mjs
+++ b/apps/cli/scripts/vendor-assets.mjs
@@ -17,7 +17,7 @@
 
 import { copyFileSync, existsSync, mkdirSync } from "node:fs";
 import { createRequire } from "node:module";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const require = createRequire(import.meta.url);
@@ -50,7 +50,7 @@ function resolve(specifier, what) {
 // serves `${bundle}.map` derived from whatever path it resolved, so the map has
 // to land beside its bundle here too.
 function copyWithMap(from, toDir) {
-  const name = from.split("/").pop();
+  const name = basename(from);
   copyFileSync(from, join(toDir, name));
   if (existsSync(`${from}.map`)) {
     copyFileSync(`${from}.map`, join(toDir, `${name}.map`));

--- a/packages/overlay/scripts/check-css.mjs
+++ b/packages/overlay/scripts/check-css.mjs
@@ -16,8 +16,9 @@
  */
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const DIR = new URL("../src/styles/", import.meta.url).pathname;
+const DIR = fileURLToPath(new URL("../src/styles/", import.meta.url));
 const START = /export const css\s*=\s*`/;
 const problems = [];
 


### PR DESCRIPTION
A fresh clone fails to build on Windows in three independent ways. This PR fixes all three; after it, `pnpm install && pnpm build` completes with all 11 packages green on Windows 11 / Node 24 / pnpm 11.9.0 (and nothing changes on macOS/Linux).

## The three failures

**1. `packages/overlay/scripts/check-css.mjs` — doubled drive letter**

The styles directory was resolved with `new URL(...).pathname`, which on Windows yields `/C:/Users/...`; `readdirSync` then resolves it against the current drive and looks for `C:\C:\Users\...`:

```
Error: ENOENT: no such file or directory, scandir 'C:\C:\Users\Kevin\Airship\packages\overlay\src\styles\'
```

Fixed by using `fileURLToPath`, which the sibling scripts already use.

**2. `apps/cli/scripts/vendor-assets.mjs` — asset name derived by splitting on `/`**

`from.split(/).pop()` is a no-op on the backslash paths `require.resolve` returns on Windows, so the whole absolute source path got appended to the destination:

```
Error: ENOENT: ... copyfile '...' -> 'C:\...\apps\cli\dist\vendor\C:\...\packages\overlay\dist\overlay.global.js'
```

Fixed with `path.basename`.

**3. CRLF checkout breaks the token/icon gen scripts**

With `core.autocrlf=true` (the Git-for-Windows default), the markdown specs check out with CRLF, and the `/^---\n/` front-matter regexes in the `editor-tokens`, `editor-icons` and `site-tokens` gen scripts no longer match:

```
Error: gen: EDITOR.md is missing its YAML front-matter block
```

Fixed by adding a `.gitattributes` with `* text=auto eol=lf`, so every clone checks out with LF regardless of local Git config. (The repo's blobs are already all LF, so this renormalizes nothing.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)