### PR TITLE
fix(ci): publish from main, after npm, with the provenance flake retried

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,9 +7,17 @@ run-name: "Publish · ${{ inputs.version || inputs.bump }}${{ inputs.dry_run && 
 # cli-vX.Y.Z and pushes — the CI equivalent of `make release` plus pushing the
 # tag, with no local steps.
 #
-# Run it from your release/* branch: the version-bump commit lands there and
-# reaches main through the normal release PR. branch-policy.yml is what makes
-# that the only route in.
+# Run it from main. What goes to npm should be what was reviewed, merged and
+# checked — and the only way to guarantee that is to publish the tree main
+# actually has. This used to run from release/* so the version-bump commit
+# would reach main through a PR; that protected a package.json version field
+# and a lockfile while leaving the shipped tree ungated, and it showed: v0.2.2
+# and v0.2.3 both went out from release/cli-readme before that branch had a
+# pull request or a single Checks run, reaching users seven minutes before
+# they reached main.
+#
+# The bump commit this job pushes to main is mechanical and there is nothing in
+# it to review. branch-policy.yml still governs the route for everything else.
 #
 # Note: the cli-v* tag is pushed with GITHUB_TOKEN, which by design does NOT
 # trigger release.yml — so this workflow publishes here, and the two lanes can
@@ -47,6 +55,20 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
+      # First, and before the checkout, so a misdirected release costs three
+      # seconds instead of a version. Dry runs are exempt: they publish nothing
+      # and push nothing, and validating packaging from a branch before you
+      # merge it is exactly what they are for.
+      - name: Releases come from main
+        if: ${{ inputs.dry_run == false }}
+        run: |
+          if [ "$GITHUB_REF_NAME" != "main" ]; then
+            echo "::error::Publish runs on main, not '$GITHUB_REF_NAME' — this would ship code main does not have."
+            echo "  Merge the PR first, then dispatch this on main."
+            echo "  To validate packaging from this branch instead: make release:ci DRY=1"
+            exit 1
+          fi
+
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
@@ -165,6 +187,9 @@ jobs:
 
       - name: Commit, tag and push
         if: ${{ inputs.dry_run == false }}
+        env:
+          TAG: ${{ steps.ver.outputs.tag }}
+          NEXT: ${{ steps.ver.outputs.next }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -172,9 +197,22 @@ jobs:
           # --no-verify skips the husky commit-msg and pre-push hooks. The
           # pre-push hook blocks pushes to main, and commit-msg would reject
           # nothing here, but both are pointless in CI.
-          git commit --no-verify -m "chore(release): cli v${{ steps.ver.outputs.next }}"
-          git tag -a "${{ steps.ver.outputs.tag }}" -m "${{ steps.ver.outputs.tag }}"
-          git push --no-verify origin "HEAD:${{ github.ref_name }}" --follow-tags
+          git commit --no-verify -m "chore(release): cli v$NEXT"
+          git tag -a "$TAG" -m "$TAG"
+
+          # The tag goes first and on its own, rather than riding along on
+          # --follow-tags. It is the release record — it names the exact tree
+          # npm now has — and a tag ref cannot lose a race to a merge the way a
+          # branch ref can. Rebasing to win that race is not an option: it would
+          # move the commit off the tree that was actually published.
+          git push --no-verify origin "refs/tags/$TAG"
+
+          if ! git push --no-verify origin "HEAD:$GITHUB_REF_NAME"; then
+            echo "::error::v$NEXT is published and tagged, but main moved during the run and the bump commit did not land."
+            echo "  The release itself is complete — only the bookkeeping commit is missing."
+            echo "  Put it on main with: git cherry-pick $TAG"
+            exit 1
+          fi
 
       # Last, and after the push on purpose. This checks a release that npm has
       # already made permanent — it cannot prevent a bad one, only make it loud

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,9 +3,9 @@ name: Publish (CI)
 run-name: "Publish · ${{ inputs.version || inputs.bump }}${{ inputs.dry_run && ' (dry-run)' || '' }}"
 
 # All-in-CI release for @airshiplabs/cli: pick a bump (or an explicit version)
-# and this bumps apps/cli/package.json, commits, tags cli-vX.Y.Z, pushes, and
-# publishes — the CI equivalent of `make release` plus pushing the tag, with no
-# local steps.
+# and this bumps apps/cli/package.json, builds, publishes, then commits and tags
+# cli-vX.Y.Z and pushes — the CI equivalent of `make release` plus pushing the
+# tag, with no local steps.
 #
 # Run it from your release/* branch: the version-bump commit lands there and
 # reaches main through the normal release PR. branch-policy.yml is what makes
@@ -14,6 +14,10 @@ run-name: "Publish · ${{ inputs.version || inputs.bump }}${{ inputs.dry_run && 
 # Note: the cli-v* tag is pushed with GITHUB_TOKEN, which by design does NOT
 # trigger release.yml — so this workflow publishes here, and the two lanes can
 # never double-publish.
+#
+# Nothing reaches the remote until npm has the version, so a failed run is a
+# re-dispatch and nothing else. If a run ever does die between the publish and
+# the push, finish it from release.yml's workflow_dispatch — don't re-cut it.
 on:
   workflow_dispatch:
     inputs:
@@ -74,10 +78,41 @@ jobs:
           echo "tag=cli-v$NEXT" >> "$GITHUB_OUTPUT"
           echo "::notice::Releasing @airshiplabs/cli v$NEXT (tag cli-v$NEXT)"
 
-      - name: Guard against an existing tag
+      # Asks git AND npm, because those two can disagree — that is the whole
+      # failure this job is now built around. A bare "tag already exists" is
+      # what you got when v0.2.4 was tagged but never published, and it named
+      # the symptom while hiding both the cause and the way out.
+      #
+      # A network failure on `npm view` reads as "not published", which sends
+      # the job on to publish; npm rejects the duplicate there, before anything
+      # is pushed. So the ambiguous case fails on the npm side, never on git's.
+      - name: Guard against an existing release
+        env:
+          TAG: ${{ steps.ver.outputs.tag }}
+          NEXT: ${{ steps.ver.outputs.next }}
         run: |
-          if git rev-parse -q --verify "refs/tags/${{ steps.ver.outputs.tag }}" >/dev/null; then
-            echo "::error::Tag ${{ steps.ver.outputs.tag }} already exists."
+          tagged=0
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            tagged=1
+          fi
+          published=0
+          if npm view "@airshiplabs/cli@$NEXT" version >/dev/null 2>&1; then
+            published=1
+          fi
+
+          if [ "$tagged" = 1 ] && [ "$published" = 1 ]; then
+            echo "::error::v$NEXT is already released — tag $TAG exists and npm has it. Pick a different version."
+            exit 1
+          fi
+          if [ "$tagged" = 1 ] && [ "$published" = 0 ]; then
+            echo "::error::v$NEXT is half-released: tag $TAG exists but npm never got the package."
+            echo "  Finish it instead of re-cutting it — run the Release workflow with tag=$TAG."
+            echo "  gh workflow run release.yml -f tag=$TAG"
+            exit 1
+          fi
+          if [ "$tagged" = 0 ] && [ "$published" = 1 ]; then
+            echo "::error::npm already has v$NEXT but tag $TAG does not exist — npm ran ahead of git."
+            echo "  Push the tag for the commit that shipped it; do not re-publish."
             exit 1
           fi
 
@@ -113,6 +148,21 @@ jobs:
       - name: Validate packaging
         run: bash scripts/verify-tarball.sh "${{ steps.pack.outputs.tgz }}"
 
+      # Publishing comes BEFORE the push, and the order is the point. This used
+      # to push the release commit and the tag first, so when npm failed the
+      # run left git claiming a release npm had never seen — and the tag guard
+      # above then blocked every re-run of that same version. v0.2.4 stranded
+      # exactly that way. Nothing here writes to the remote until the version is
+      # actually on npm, so every failure up to this line is just a re-dispatch.
+      #
+      # The tarball is the one "Validate packaging" just looked inside — packed
+      # after the bump, so it already carries the released version.
+      - name: Publish to npm
+        if: ${{ inputs.dry_run == false }}
+        run: bash scripts/npm-publish.sh "${{ steps.pack.outputs.tgz }}"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Commit, tag and push
         if: ${{ inputs.dry_run == false }}
         run: |
@@ -126,14 +176,10 @@ jobs:
           git tag -a "${{ steps.ver.outputs.tag }}" -m "${{ steps.ver.outputs.tag }}"
           git push --no-verify origin "HEAD:${{ github.ref_name }}" --follow-tags
 
-      # The same tarball "Validate packaging" just looked inside — packed after
-      # the bump, so it already carries the released version.
-      - name: Publish to npm
-        if: ${{ inputs.dry_run == false }}
-        run: npm publish "${{ steps.pack.outputs.tgz }}" --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
+      # Last, and after the push on purpose. This checks a release that npm has
+      # already made permanent — it cannot prevent a bad one, only make it loud
+      # (see the script's own header). Gating the push on it would strand a
+      # perfectly good release in the opposite direction.
       - name: The npm page has a README
         if: ${{ inputs.dry_run == false }}
         run: bash scripts/verify-published-readme.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: Release
 
-run-name: "Release · ${{ github.ref_name }}"
+run-name: "Release · ${{ inputs.tag || github.ref_name }}"
 
 # Publishes @airshiplabs/cli to npm when a cli-v* tag is pushed. Cut the release
 # with `make release` (bumps apps/cli/package.json, commits, tags) then push the
@@ -9,19 +9,41 @@ run-name: "Release · ${{ github.ref_name }}"
 # This lane is for locally-cut releases only. publish.yml pushes its tag with
 # GITHUB_TOKEN, and GitHub does not fire workflows from GITHUB_TOKEN-authored
 # pushes, so a CI-cut release never lands here and the two never both publish.
+#
+# It is also the recovery lane, which is what workflow_dispatch is for: give it
+# an existing tag and it publishes that tag's commit. A release whose tag landed
+# but whose publish did not is finished from here — no deleting and re-pushing
+# the tag to fake a push event, and no version burned. That is the hole v0.2.4
+# fell into.
 on:
   push:
     tags: ["cli-v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing cli-v* tag to publish, e.g. cli-v1.4.0"
+        type: string
+        required: true
 
 permissions:
   contents: read
   id-token: write # npm provenance attestation
 
+# Shared with publish.yml: both lanes publish the same package, and now that
+# both can be triggered by hand they must not run at the same time.
+concurrency:
+  group: publish
+  cancel-in-progress: false
+
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
+      # On a tag push this is what checkout would pick anyway; on a dispatch it
+      # is what makes the run about the given tag rather than the default branch.
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.tag || github.ref_name }}
 
       - uses: pnpm/action-setup@v6
 
@@ -33,9 +55,22 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # This is what keeps the dispatch honest: whatever tag you hand it, the
+      # commit it points at has to already carry that version.
       - name: Verify the tag matches apps/cli's version
+        env:
+          # A dispatch input is untrusted text, so read it from the environment
+          # rather than interpolating ${{ }} into the script — same reason
+          # branch-policy.yml does that with head_ref.
+          TAG_REF: ${{ inputs.tag || github.ref_name }}
         run: |
-          TAG="${GITHUB_REF_NAME#cli-v}"
+          case "$TAG_REF" in
+            cli-v*) ;;
+            *)
+              echo "::error::'$TAG_REF' is not a cli-v* tag — pass one like cli-v1.4.0."
+              exit 1 ;;
+          esac
+          TAG="${TAG_REF#cli-v}"
           PKG=$(node -p "require('./apps/cli/package.json').version")
           if [ "$TAG" != "$PKG" ]; then
             echo "::error::Tag cli-v$TAG does not match @airshiplabs/cli version $PKG (cut releases with 'make release')"
@@ -72,7 +107,7 @@ jobs:
         run: bash scripts/verify-tarball.sh "${{ steps.pack.outputs.tgz }}"
 
       - name: Publish to npm
-        run: npm publish "${{ steps.pack.outputs.tgz }}" --access public --provenance
+        run: bash scripts/npm-publish.sh "${{ steps.pack.outputs.tgz }}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/Makefile
+++ b/Makefile
@@ -283,7 +283,7 @@ demo: ## One-shot: install + build, then print the two-terminal recipe
 
 ##@ Release (@airshiplabs/cli)
 
-.PHONY: readme release release\:ci release\:version
+.PHONY: readme release release\:ci release\:retry release\:version
 
 readme: ## Regenerate apps/cli/README.md from the root README.md
 	@node scripts/sync-readme.mjs
@@ -296,6 +296,11 @@ release\:ci: ## Trigger the CI publish workflow. BUMP=patch|minor|major, VERSION
 	@gh workflow run publish.yml --ref "$$(git rev-parse --abbrev-ref HEAD)" \
 		-f bump="$(or $(BUMP),patch)" -f version="$(VERSION)" -f dry_run="$(if $(DRY),true,false)"
 	@echo "Dispatched publish on $$(git rev-parse --abbrev-ref HEAD). Watch: gh run watch"
+
+release\:retry: ## Publish a tag that never reached npm. TAG=cli-vX.Y.Z
+	@test -n "$(TAG)" || { echo "release:retry needs TAG=cli-vX.Y.Z"; exit 1; }
+	@gh workflow run release.yml -f tag="$(TAG)"
+	@echo "Dispatched release for $(TAG). Watch: gh run watch"
 
 release\:version: ## Print the version the next release would get (BUMP=, VERSION=)
 	@node scripts/next-version.mjs $(if $(VERSION),--version "$(VERSION)",--bump "$(or $(BUMP),patch)")

--- a/scripts/npm-publish.sh
+++ b/scripts/npm-publish.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Publishes a packed tarball to npm with provenance, retrying the Sigstore flake.
+#
+# Why this exists: `--provenance` makes npm POST a signed provenance bundle to
+# Sigstore's Rekor transparency log before the package goes out. When that POST
+# hangs, npm's own HTTP layer retries the IDENTICAL payload and Rekor answers
+#
+#   npm error code TLOG_CREATE_ENTRY_ERROR
+#   npm error error creating tlog entry - (409) an equivalent entry already
+#   exists in the transparency log
+#
+# — a duplicate rejection, not a real failure. That is how v0.2.4 died: git got
+# the release commit and the tag, npm never got the package, and the run turned
+# red 42 seconds into a publish that had nothing wrong with it.
+#
+# Retrying HERE works where npm's internal retry cannot. npm's retry replays the
+# same bytes and the same signature, so Rekor keeps seeing a duplicate; a fresh
+# `npm publish` process mints a new ephemeral signing key, which produces a
+# different log entry that Rekor accepts.
+#
+#   bash scripts/npm-publish.sh <tarball>
+#
+# Only transient codes are retried — an expired token fails on the first attempt
+# rather than burning a minute proving it three times.
+#
+# Env knobs:
+#   ATTEMPTS=n   how many publishes to try (default 3)
+#   DELAY=n      seconds before the second attempt, doubled for the third
+#                (default 15) — set to 0 to exercise the retry paths in a test
+set -euo pipefail
+
+PKG_NAME="@airshiplabs/cli"
+ATTEMPTS="${ATTEMPTS:-3}"
+DELAY="${DELAY:-15}"
+
+TGZ="${1:-}"
+if [ -z "$TGZ" ]; then
+  echo "npm-publish: usage: npm-publish.sh <tarball>" >&2
+  exit 1
+fi
+
+# Resolve the argument before cd'ing, so a relative path still works.
+TGZ="$(cd "$(dirname "$TGZ")" && pwd)/$(basename "$TGZ")"
+[ -f "$TGZ" ] || { echo "npm-publish: $TGZ not found" >&2; exit 1; }
+
+# Publish from the repo root, which is where both workflows used to run this
+# inline. Auth comes from NPM_CONFIG_USERCONFIG, not from cwd, but the repo
+# .npmrc is read from here and this keeps the two identical.
+cd "$(git rev-parse --show-toplevel)"
+
+LOG="$(mktemp)"
+trap 'rm -f "$LOG"' EXIT
+
+for attempt in $(seq 1 "$ATTEMPTS"); do
+  echo "» publishing $(basename "$TGZ") (attempt $attempt/$ATTEMPTS)"
+
+  # PIPESTATUS, not the pipeline's status: `tee` succeeds even when npm does
+  # not, and streaming the output is what makes a failed publish readable in
+  # the Actions log.
+  set +e
+  npm publish "$TGZ" --access public --provenance 2>&1 | tee "$LOG"
+  status="${PIPESTATUS[0]}"
+  set -e
+
+  if [ "$status" -eq 0 ]; then
+    echo "✓ published $PKG_NAME"
+    exit 0
+  fi
+
+  code="$(sed -n 's/^npm error code \(.*\)$/\1/p' "$LOG" | head -1)"
+
+  # A conflict on a LATER attempt means an earlier attempt this run actually
+  # reached the registry and only its response was lost — the publish landed,
+  # so this run succeeded. On the first attempt it means the version was
+  # already on npm before we started, which is a real error: we were asked to
+  # publish and published nothing.
+  if [ "$code" = "EPUBLISHCONFLICT" ]; then
+    if [ "$attempt" -gt 1 ]; then
+      echo
+      echo "✓ attempt $((attempt - 1)) landed after all — the registry already has this version"
+      exit 0
+    fi
+    echo >&2
+    echo "::error::npm already has this version of $PKG_NAME — nothing was published." >&2
+    echo "  A version is spent the moment it goes out; npm never lets you replace one." >&2
+    echo "  Release the next version instead." >&2
+    exit "$status"
+  fi
+
+  case "$code" in
+    TLOG_CREATE_ENTRY_ERROR | ETIMEDOUT | ECONNRESET | EAI_AGAIN | ERR_SOCKET_TIMEOUT | E5[0-9][0-9]) ;;
+    *)
+      echo >&2
+      echo "::error::$PKG_NAME publish failed with ${code:-no error code} — not retrying." >&2
+      echo "  Only transient codes are retried; this one needs a fix, not another attempt." >&2
+      exit "$status"
+      ;;
+  esac
+
+  if [ "$attempt" -lt "$ATTEMPTS" ]; then
+    wait_for=$((DELAY * attempt))
+    echo
+    echo "  $code is transient — retrying in ${wait_for}s with a fresh signing key"
+    sleep "$wait_for"
+  fi
+done
+
+echo >&2
+echo "::error::$PKG_NAME publish failed $ATTEMPTS times — last code was ${code:-unknown}." >&2
+echo "  Nothing was pushed to git, so re-running this workflow is safe." >&2
+exit 1

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -55,9 +55,13 @@ done
 cd "$(git rev-parse --show-toplevel)" || die "not inside a git repository"
 [ -f "$PKG_JSON" ] || die "$PKG_JSON not found"
 
+# Releases go out from main, because what ships to npm should be what was
+# reviewed and merged. Cutting from a branch publishes the branch: v0.2.2 and
+# v0.2.3 both reached users from release/cli-readme before that branch had a
+# pull request, a Checks run, or a single reviewer.
 BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-if [ "$BRANCH" = "main" ]; then
-  warn "you are on main — releases normally go out from a release/* branch"
+if [ "$BRANCH" != "main" ]; then
+  warn "you are on '$BRANCH' — releases go out from main, so this would ship unmerged code"
 fi
 
 if [ -z "${ALLOW_DIRTY:-}" ] && [ -n "$(git status --porcelain)" ]; then


### PR DESCRIPTION
Two problems, one incident. v0.2.4 was tagged on `main` and never reached npm.

## 1. The publish flaked, and the ordering made it unrecoverable

[Run 31528825150](https://github.com/0xnyn/airship/actions/runs/31528825150) bumped, committed, tagged and pushed — then died on the last step:

```
npm error code TLOG_CREATE_ENTRY_ERROR
npm error error creating tlog entry - (409) an equivalent entry already exists
in the transparency log
```

`--provenance` POSTs a signed bundle to Sigstore's Rekor log. That POST hung (42s), npm's HTTP layer replayed the **identical** payload, and Rekor rejected the duplicate. Nothing was wrong with the publish.

Because `publish.yml` pushed git state *before* publishing, the flake stranded the release: tag `cli-v0.2.4` and a release commit on `main`, npm still on 0.2.3. The tag guard then blocked every re-run of that version, and `release.yml` — the lane that could have finished it — only fires on a tag push.

0.2.4 is on npm now, published by re-pushing the tag by hand ([run 31531809787](https://github.com/0xnyn/airship/actions/runs/31531809787)).

- **`scripts/npm-publish.sh`** (new) — retries the publish. npm's internal retry replays the same signature so Rekor keeps seeing a duplicate; a fresh process mints a new ephemeral signing key and gets a new log entry. Transient codes only (a bad token fails on attempt 1), and `EPUBLISHCONFLICT` on a *later* attempt means an earlier one landed and its response was lost — a success, not a failure.
- **Publish before push.** Every failure up to that line now leaves the remote untouched, so the fix is a re-dispatch. The README check moves last, after the push: it checks a release npm already made permanent, so gating the push on it would only strand things the other way.
- **The guard asks npm as well as git** and branches on all four states, so the half-released case says what it is and points at the fix.
- **`release.yml` takes a `workflow_dispatch` tag** — the permanent recovery lane, also `make release:retry TAG=cli-vX.Y.Z`. Both lanes now share the `publish` concurrency group.

## 2. Releases were cut from `release/*`, which shipped unreviewed code

The stated reason was that the version-bump commit should reach `main` through a PR. That guarded a `package.json` version field and a lockfile while leaving the shipped tree completely ungated. On `release/cli-readme`:

| time | event |
|---|---|
| 00:33:19 | **v0.2.2 published to npm** |
| 00:44:45 | **v0.2.3 published to npm** |
| 00:48:18 | PR #10 opened — first chance to review any of it |
| 00:48:21 | `Checks` and `Branch policy` run for the first time |
| 00:51:33 | merged to `main` |

Two versions reached users from a branch with no pull request, no CI run and no reviewer, seven minutes before the code reached `main`. And `main` is not branch-protected (`gh api .../protection` → 404), so the PR route was never enforced anyway.

- **Publish runs on `main`**, so npm gets the tree that was reviewed, merged and checked. Guarded as the first step, before checkout, so a misdirected release costs six seconds instead of a version.
- **Dry runs stay unrestricted** — they publish and push nothing, and validating packaging from a branch before merging is what they are for.
- **The tag is pushed on its own, ahead of the branch.** `main` takes merges a release branch did not, so the bump commit can lose a race that a tag ref cannot; rebasing to win it would move the commit off the tree that was published. If the branch push loses, the release is still complete and recorded by the tag, and the job names the cherry-pick that finishes it.
- `scripts/release.sh` warns off non-`main` branches instead of onto them.

## Verification

- `actionlint`, `shellcheck`, `pnpm lint` clean.
- Every branch of `npm-publish.sh` exercised against a stubbed `npm`: clean success, flake-then-success, flake-then-lost-response-409, bad token (fails fast, 1 attempt), conflict on attempt 1 (fails, names the state), transient all the way down (3 attempts then fails), 503 retried.
- Reordered workflow dry-run from this branch: [green](https://github.com/0xnyn/airship/actions/runs/31533320837), steps in the new order, publish/push/README skipped.
- Guard against an existing release, live against the real 0.2.4 state: [fails](https://github.com/0xnyn/airship/actions/runs/31532560858) before the bump with *"v0.2.4 is already released — tag cli-v0.2.4 exists and npm has it."*
- Main-only guard, live from this branch: [fails in 6s](https://github.com/0xnyn/airship/actions/runs/31533264623) before checkout.

`release.yml`'s `workflow_dispatch` cannot be exercised until this merges — GitHub only exposes it for workflows on the default branch.
