### PR TITLE
docs: fix inconsistent capitalization in DESIGN.md

### DIFF
--- a/packages/site-tokens/DESIGN.md
+++ b/packages/site-tokens/DESIGN.md
@@ -1,7 +1,7 @@
 ---
 name: Airship Site
 description: >-
-  The design system for airship's home page — a warm neutral stone ramp, hairline
+  The design system for Airship's home page — a warm neutral stone ramp, hairline
   rules instead of shadows, a single near-black call to action, and no accent hue
   in the page chrome at all. Hierarchy comes from size, weight and space. This
   front-matter is the canonical token source for `@airship/site-tokens` (emitted


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `packages/site-tokens/DESIGN.md` (line 4).

## Problem

The product name "Airship" is lowercase ("airship's") in the frontmatter description, inconsistent with the capitalized "Airship" used elsewhere in the same file and in the README.

The problematic text:

```markdown
The design system for airship's home page
```

## Fix

Replaced with:

```markdown
The design system for Airship's home page
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text