### PR TITLE
docs: fix wrong pronoun in CLI README

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -149,7 +149,7 @@ inspector are open on either side of it.
 
 **View** is about your frames. The page underneath is fully interactive — click through it,
 fill in forms, scroll — so there is no element selection, and the two panels that depend on
-one step aside. In their place the left panel lists every frame, and a minimap appears in
+it step aside. In their place the left panel lists every frame, and a minimap appears in
 the bottom-right corner:
 
 - Click a frame in the list to go to it without changing your zoom; double-click to zoom


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `apps/cli/README.md` (line 152).

## Problem

The pronoun "one" has no clear antecedent and is grammatically incorrect in this context. It should be "it" referring back to "element selection" in the preceding clause.

The problematic text:

```markdown
the two panels that depend on one step aside
```

## Fix

Replaced with:

```markdown
the two panels that depend on it step aside
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text