### PR TITLE
feat(overlay): toggle the mode and the panels from the keyboard

### DIFF
--- a/CONTROLS.md
+++ b/CONTROLS.md
@@ -35,7 +35,7 @@ the editor also answers to a plain `+` and `-`.
 
 | Command | macOS | Windows / Linux | Where | |
 | --- | --- | --- | --- | --- |
-| Toggle Edit / View | ⌘E | Ctrl+E | anywhere | Switch between Edit and View. Edit selects and inspects; View leaves the page interactive. |
+| Toggle Edit / View | ⌘E or ⌘. | Ctrl+E or Ctrl+. | anywhere | Switch between Edit and View. Edit selects and inspects; View leaves the page interactive. |
 | Zoom in | ⌘= or = | Ctrl+= or = | canvas only | Zoom in a step, centred on the canvas. On Safari, use + rather than ⌘+. |
 | Zoom out | ⌘- or - | Ctrl+- or - | canvas only | Zoom out a step. On Safari, use − rather than ⌘−. |
 | Zoom to 100% | ⌘0 or ⇧0 | Ctrl+0 or Shift+0 | canvas only | Return the canvas to actual size. |

--- a/CONTROLS.md
+++ b/CONTROLS.md
@@ -35,6 +35,7 @@ the editor also answers to a plain `+` and `-`.
 
 | Command | macOS | Windows / Linux | Where | |
 | --- | --- | --- | --- | --- |
+| Toggle Edit / View | ⌘E | Ctrl+E | anywhere | Switch between Edit and View. Edit selects and inspects; View leaves the page interactive. |
 | Zoom in | ⌘= or = | Ctrl+= or = | canvas only | Zoom in a step, centred on the canvas. On Safari, use + rather than ⌘+. |
 | Zoom out | ⌘- or - | Ctrl+- or - | canvas only | Zoom out a step. On Safari, use − rather than ⌘−. |
 | Zoom to 100% | ⌘0 or ⇧0 | Ctrl+0 or Shift+0 | canvas only | Return the canvas to actual size. |
@@ -51,6 +52,13 @@ the editor also answers to a plain `+` and `-`.
 | Delete frame | ⌫ or Del | Backspace or Del | view mode, canvas only | Remove the active frame from the canvas. |
 | Bring frame forward | ↑ | ↑ | on a frame's handle | Move the frame up the stack, so it covers the ones it overlaps. |
 | Send frame backward | ↓ | ↓ | on a frame's handle | Move the frame down the stack, behind the ones it overlaps. |
+
+## Panels
+
+| Command | macOS | Windows / Linux | Where | |
+| --- | --- | --- | --- | --- |
+| Toggle the left panel | ⌘\ | Ctrl+\ | anywhere | Show or hide the left panel: the chat in Edit, the frame list in View. |
+| Toggle the Design panel | ⌘⇧\ | Ctrl+Shift+\ | edit mode | Show or hide the Design panel. It only exists in Edit mode, so the key is quiet in View. |
 
 ## Agent
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ catalog, so it cannot drift from what the keys actually do:
 | edit text | ↩ or T | Enter or T |
 | move | V | V |
 | inspect | I | I |
-| toggle edit / view | ⌘E | Ctrl+E |
+| toggle edit / view | ⌘E or ⌘. | Ctrl+E or Ctrl+. |
 | zoom in | ⌘= or = | Ctrl+= or = |
 | zoom out | ⌘- or - | Ctrl+- or - |
 | zoom to 100% | ⌘0 or ⇧0 | Ctrl+0 or Shift+0 |

--- a/README.md
+++ b/README.md
@@ -125,12 +125,15 @@ catalog, so it cannot drift from what the keys actually do:
 | edit text | ↩ or T | Enter or T |
 | move | V | V |
 | inspect | I | I |
+| toggle edit / view | ⌘E | Ctrl+E |
 | zoom in | ⌘= or = | Ctrl+= or = |
 | zoom out | ⌘- or - | Ctrl+- or - |
 | zoom to 100% | ⌘0 or ⇧0 | Ctrl+0 or Shift+0 |
 | zoom to fit | ⇧1 | Shift+1 |
 | hand tool | H | H |
 | add a frame | F | F |
+| toggle the left panel | ⌘\ | Ctrl+\ |
+| toggle the design panel | ⌘⇧\ | Ctrl+Shift+\ |
 | send | ⌘↩ | Ctrl+Enter |
 | keyboard shortcuts | ? | ? |
 | command palette | ⌘K | Ctrl+K |

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -127,7 +127,7 @@ catalog, so it cannot drift from what the keys actually do:
 | edit text | ↩ or T | Enter or T |
 | move | V | V |
 | inspect | I | I |
-| toggle edit / view | ⌘E | Ctrl+E |
+| toggle edit / view | ⌘E or ⌘. | Ctrl+E or Ctrl+. |
 | zoom in | ⌘= or = | Ctrl+= or = |
 | zoom out | ⌘- or - | Ctrl+- or - |
 | zoom to 100% | ⌘0 or ⇧0 | Ctrl+0 or Shift+0 |

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -127,12 +127,15 @@ catalog, so it cannot drift from what the keys actually do:
 | edit text | ↩ or T | Enter or T |
 | move | V | V |
 | inspect | I | I |
+| toggle edit / view | ⌘E | Ctrl+E |
 | zoom in | ⌘= or = | Ctrl+= or = |
 | zoom out | ⌘- or - | Ctrl+- or - |
 | zoom to 100% | ⌘0 or ⇧0 | Ctrl+0 or Shift+0 |
 | zoom to fit | ⇧1 | Shift+1 |
 | hand tool | H | H |
 | add a frame | F | F |
+| toggle the left panel | ⌘\ | Ctrl+\ |
+| toggle the design panel | ⌘⇧\ | Ctrl+Shift+\ |
 | send | ⌘↩ | Ctrl+Enter |
 | keyboard shortcuts | ? | ? |
 | command palette | ⌘K | Ctrl+K |

--- a/packages/overlay/src/app.ts
+++ b/packages/overlay/src/app.ts
@@ -922,6 +922,25 @@ export class AirshipApp {
           },
           when: live,
         },
+        // Mode and panels from the keyboard. Each is the key for a button that
+        // is already on screen, and each `when` is that button's own
+        // condition: the mode toggle is always there; the left pill or header
+        // is always there; the Design panel has no home in view mode
+        // (`dockVisible`), so its key declines rather than flipping a flag the
+        // user could not see the effect of until the next mode switch.
+        {
+          id: "mode.toggle",
+          run: () => this.setEditing(!this.editing),
+        },
+        {
+          id: "dock.left",
+          run: () => this.setLeft(!this.leftOpen),
+        },
+        {
+          id: "dock.right",
+          run: () => this.setRight(!this.rightOpen),
+          when: () => this.editing,
+        },
         // The two discovery surfaces. Ungated: they document both modes and
         // both surfaces, and a help sheet you can only reach from the mode you
         // already understand is the wrong way round.

--- a/packages/overlay/src/keys/catalog.ts
+++ b/packages/overlay/src/keys/catalog.ts
@@ -273,12 +273,17 @@ export const COMMANDS = [
 
   // -- View -----------------------------------------------------------------
   {
-    // One chord for both directions rather than a pair. The bar's segmented
+    // One command for both directions rather than a pair. The bar's segmented
     // control is the same shape — two buttons, one of them lit — and a toggle
     // reads off that state, so the key always does what pressing the *other*
-    // segment would. Two chords would also have doubled the ways to collide
-    // with a browser's own bindings; ⌘E is taken by nothing that matters in
-    // Chrome or Safari (find-by-selection, which the editor pre-empts anyway).
+    // segment would.
+    //
+    // Two chords, because this is the one command a browser is most likely to
+    // steal. ⌘E is find-by-selection in Chrome and Safari, which the editor
+    // pre-empts; but Chromium forks hang their own furniture on it (Dia takes
+    // it at the browser level, before the page sees it). ⌘. is "stop loading"
+    // everywhere, harmless on a loaded page, and pages may pre-empt it. Both
+    // are bound and both are shown, so whichever a browser leaves alone works.
     //
     // `inFrame`, necessarily: in view mode the page in a frame has focus, and
     // a shortcut back to edit mode that goes dead the moment you use the page
@@ -289,7 +294,7 @@ export const COMMANDS = [
     icon: "edit-mode",
     id: "mode.toggle",
     inFrame: true,
-    keys: ["mod+e"],
+    keys: ["mod+e", "mod+."],
     mode: "any",
     surface: "both",
     title: "Toggle Edit / View",

--- a/packages/overlay/src/keys/catalog.ts
+++ b/packages/overlay/src/keys/catalog.ts
@@ -49,6 +49,7 @@ export type CommandGroup =
   | "Frames"
   | "Help"
   | "Menus"
+  | "Panels"
   | "Selection"
   | "View";
 
@@ -272,6 +273,28 @@ export const COMMANDS = [
 
   // -- View -----------------------------------------------------------------
   {
+    // One chord for both directions rather than a pair. The bar's segmented
+    // control is the same shape — two buttons, one of them lit — and a toggle
+    // reads off that state, so the key always does what pressing the *other*
+    // segment would. Two chords would also have doubled the ways to collide
+    // with a browser's own bindings; ⌘E is taken by nothing that matters in
+    // Chrome or Safari (find-by-selection, which the editor pre-empts anyway).
+    //
+    // `inFrame`, necessarily: in view mode the page in a frame has focus, and
+    // a shortcut back to edit mode that goes dead the moment you use the page
+    // is the one case this command exists for.
+    doc: "Switch between Edit and View. Edit selects and inspects; View leaves the page interactive.",
+    essential: true,
+    group: "View",
+    icon: "edit-mode",
+    id: "mode.toggle",
+    inFrame: true,
+    keys: ["mod+e"],
+    mode: "any",
+    surface: "both",
+    title: "Toggle Edit / View",
+  },
+  {
     doc: "Zoom in a step, centred on the canvas. On Safari, use + rather than ⌘+.",
     essential: true,
     group: "View",
@@ -405,6 +428,37 @@ export const COMMANDS = [
     surface: "canvas",
     title: "Send frame backward",
     where: "on a frame's handle",
+  },
+
+  // -- Panels ---------------------------------------------------------------
+  // The two dock headers carry show/hide buttons already; these are the same
+  // verbs from the keyboard. ⌘\ is the design-tool convention for folding
+  // chrome away (Figma, Sketch), and the pair is spelled as left / shift-left
+  // rather than as two unrelated letters so that a hand that knows one knows
+  // the other. Neither is bound by Chrome or Safari.
+  {
+    doc: "Show or hide the left panel: the chat in Edit, the frame list in View.",
+    essential: true,
+    group: "Panels",
+    icon: "panel-left",
+    id: "dock.left",
+    inFrame: true,
+    keys: ["mod+\\"],
+    mode: "any",
+    surface: "both",
+    title: "Toggle the left panel",
+  },
+  {
+    doc: "Show or hide the Design panel. It only exists in Edit mode, so the key is quiet in View.",
+    essential: true,
+    group: "Panels",
+    icon: "panel-right",
+    id: "dock.right",
+    inFrame: true,
+    keys: ["mod+shift+\\"],
+    mode: "edit",
+    surface: "both",
+    title: "Toggle the Design panel",
   },
 
   // -- Agent ----------------------------------------------------------------
@@ -718,6 +772,7 @@ export const COMMAND_GROUPS: readonly CommandGroup[] = [
   "Selection",
   "View",
   "Frames",
+  "Panels",
   "Agent",
   "Help",
   "Menus",

--- a/packages/overlay/src/keys/registry.test.ts
+++ b/packages/overlay/src/keys/registry.test.ts
@@ -307,6 +307,32 @@ describe("an unscoped binding", () => {
   });
 });
 
+describe("a chord on a key whose shifted character differs", () => {
+  // ⌘⇧\ reaches the event as `key: "|"` on a US layout. The chord is spelled
+  // with the physical key, so the match has to go through `e.code`, exactly as
+  // `?` does for the shortcuts panel.
+  it("matches the panel toggle by its physical key", () => {
+    const run = vi.fn();
+    bind({ id: "dock.right", run });
+
+    press(plain(), "|", { code: "Backslash", mod: true, shift: true });
+
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the unshifted chord distinct", () => {
+    const left = vi.fn();
+    const right = vi.fn();
+    bind({ id: "dock.left", run: left });
+    bind({ id: "dock.right", run: right });
+
+    press(plain(), "\\", { code: "Backslash", mod: true });
+
+    expect(left).toHaveBeenCalledTimes(1);
+    expect(right).not.toHaveBeenCalled();
+  });
+});
+
 describe("precedence is declared, not incidental", () => {
   it("gives a modal binding the chord over an ordinary one", () => {
     const menu = vi.fn();

--- a/packages/overlay/src/keys/registry.ts
+++ b/packages/overlay/src/keys/registry.ts
@@ -62,11 +62,14 @@ const LETTER_CODE = /^Key([A-Z])$/;
 /**
  * Codes whose physical identity matters more than the character they produce.
  *
- * `Slash` is here for `?` (the shortcuts panel), and the two numpad keys because
- * a numeric keypad's `+` and `−` are the ones a lot of people reach for to zoom
- * and they arrive under names nothing else would match.
+ * `Slash` is here for `?` (the shortcuts panel), `Backslash` for the panel
+ * toggles (⌘⇧\ arrives as `"|"` on a US layout, as ⇧/ arrives as `"?"`), and
+ * the two numpad keys because a numeric keypad's `+` and `−` are the ones a lot
+ * of people reach for to zoom and they arrive under names nothing else would
+ * match.
  */
 const CODE_KEYS: Readonly<Record<string, string>> = {
+  Backslash: "\\",
   Equal: "=",
   Minus: "-",
   NumpadAdd: "numpadadd",


### PR DESCRIPTION
## What

Three commands, declared once in the catalog so the `⌘K` palette, the `?` sheet, `CONTROLS.md` and the README table all follow:

| Command | macOS | Where |
| --- | --- | --- |
| Toggle Edit / View (`mode.toggle`) | `⌘E` or `⌘.` | anywhere, including from inside a live frame |
| Toggle the left panel (`dock.left`) — chat in Edit, frames in View | `⌘\` | anywhere |
| Toggle the Design panel (`dock.right`) | `⌘⇧\` | Edit mode; quiet in View, where the panel has no home (`dockVisible`) |

New `Panels` group between Frames and Agent. Each key is the key for a button that is already on screen, and each `when` is that button's own condition.

## Why

The mode switch and the dock show/hide buttons were the only frequently-hit controls in the bar with no chord, and the mode one matters most from inside a frame: View mode puts focus in the page, and a way back to Edit that goes dead the moment you use the page is the case a shortcut exists for. All three are `inFrame` for that reason.

Chords: `⌘\` is the design-tool convention for folding chrome away (Figma, Sketch) and the shift pair keeps both panels under one hand; neither is bound by Chrome or Safari. `⌘E` is find-by-selection in Chrome/Safari, which the editor pre-empts, but a Chromium fork can take it at the browser level before the page sees it (Dia does), so `⌘.` — stop-loading everywhere, harmless on a loaded page, pre-emptable — is bound beside it. Both are shown. Happy to change any of these if you have a preference; the ids and the wiring are the part I care about.

## Registry

`Backslash` joins `CODE_KEYS`: `⌘⇧\` arrives as `"|"` on a US layout, as `⇧/` arrives as `"?"`, and the chord is spelled by the physical key. Two tests in `registry.test.ts` cover the shifted and unshifted chords staying distinct.

## Checks

`make preflight` green; overlay suite 1175/1175; `CONTROLS.md` and both READMEs regenerated with `make controls`. Verified in Chrome against a real target: all three toggle in both directions from the shell, and `⌘\` / `⌘E` fire with focus inside a live frame in View mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)